### PR TITLE
GSA instrument 옵션 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 _build
 localizer
 localizer-out
+sparrow-out
 coverage.xml
 *.gc*
 bug
+*.i

--- a/src/cmdline.ml
+++ b/src/cmdline.ml
@@ -2,11 +2,19 @@ let work_dir : string option ref = ref None
 
 let out_dir = ref "localizer-out"
 
-let instrument = ref false
+type instrument = DfSan | GSA | Nothing
+
+let instrument = ref Nothing
+
+let select_instrument s =
+  match s with
+  | "dfsan" -> instrument := DfSan
+  | "gsa" -> instrument := GSA
+  | _ -> failwith "Unknown instrument"
 
 let skip_compile = ref false
 
-type engine = Tarantula | Prophet | Dummy
+type engine = Tarantula | Prophet | Dummy | UniVal
 
 let engine = ref Dummy
 
@@ -15,12 +23,15 @@ let select_engine s =
   | "tarantula" -> engine := Tarantula
   | "prophet" -> engine := Prophet
   | "dummy" -> engine := Dummy
+  | "unival" -> engine := UniVal
   | _ -> failwith "Unknown engine"
 
 let options =
   [
     ("-outdir", Arg.Set_string out_dir, "Output directory");
-    ("-instrument", Arg.Set instrument, "Instrument based on Sparrow results");
+    ( "-instrument",
+      Arg.String select_instrument,
+      "Specify instrument method (default: Nothing)" );
     ("-skip_compile", Arg.Set skip_compile, "Skip compilation");
     ( "-engine",
       Arg.String select_engine,

--- a/src/instrument.ml
+++ b/src/instrument.ml
@@ -1,166 +1,181 @@
-module NodeInfo = struct
-  type t = Yojson.Safe.t
+module DfSan = struct
+  module NodeInfo = struct
+    type t = Yojson.Safe.t
 
-  let cmd_of t =
-    ((t |> function
-      | `Assoc l -> List.assoc "cmd" l
-      | _ -> failwith "Invalid format")
-     |> function
-     | `List l -> List.hd l
-     | _ -> failwith "Invalid format")
-    |> function
-    | `String s -> s
-    | _ -> failwith "Invalid format"
-
-  let filename_of t =
-    t
-    |> (function
-         | `Assoc l -> List.assoc "loc" l | _ -> failwith "Invalid format")
-    |> (function `String s -> s | _ -> failwith "Invalid format")
-    |> String.split_on_char ':' |> Fun.flip List.nth 0
-end
-
-module NodeInfoMap = struct
-  module M = Map.Make (String)
-
-  type t = NodeInfo.t M.t
-
-  let empty = M.empty
-
-  let add = M.add
-
-  let find = M.find
-end
-
-module LineSet = Set.Make (String)
-module FileToEdges = Map.Make (String)
-
-let read_nodes file =
-  let ic = open_in file in
-  Yojson.Safe.from_channel ic
-  |> (function
-       | `Assoc l -> List.assoc "nodes" l | _ -> failwith "Invalid format")
-  |> (function `Assoc l -> l | _ -> failwith "Invalid format")
-  |> List.fold_left
-       (fun map (name, info) -> NodeInfoMap.add name info map)
-       NodeInfoMap.empty
-  |> fun x ->
-  close_in ic;
-  x
-
-let read_covered_lines file =
-  let ic = open_in file in
-  let rec loop lst =
-    match input_line ic with
-    | line -> (
-        String.split_on_char '\t' line |> function
-        | h :: _ -> loop (LineSet.add h lst)
+    let cmd_of t =
+      ((t |> function
+        | `Assoc l -> List.assoc "cmd" l
         | _ -> failwith "Invalid format")
-    | exception End_of_file -> lst
-  in
-  loop LineSet.empty |> fun x ->
-  close_in ic;
-  x
+       |> function
+       | `List l -> List.hd l
+       | _ -> failwith "Invalid format")
+      |> function
+      | `String s -> s
+      | _ -> failwith "Invalid format"
 
-let read_duedges nodes file =
-  let ic = open_in file in
-  let rec loop map =
-    match input_line ic with
-    | line -> (
-        String.split_on_char '\t' line |> function
-        | src :: dst :: _ ->
-            let file = NodeInfoMap.find src nodes |> NodeInfo.filename_of in
-            FileToEdges.update file
-              (function
-                | None -> Some [ (src, dst) ] | Some l -> Some ((src, dst) :: l))
-              map
-            |> loop
-        | _ -> failwith "Invalid format")
-    | exception End_of_file -> map
-  in
-  loop FileToEdges.empty |> fun x ->
-  close_in ic;
-  x
-
-type dfsan_funs = {
-  create_label : Cil.varinfo;
-  set_label : Cil.varinfo;
-  get_label : Cil.varinfo;
-  has_label : Cil.varinfo;
-}
-
-let initialize work_dir =
-  let result_file = Filename.concat work_dir "result.txt" in
-  let sparrow_out_dir = Filename.concat work_dir "src/sparrow-out" in
-  let node_file = Filename.concat sparrow_out_dir "node.json" in
-  let duedge_file =
-    Filename.concat sparrow_out_dir "interval/datalog/DUEdge.facts"
-  in
-  let nodes = read_nodes node_file in
-  let lines = read_covered_lines result_file in
-  let duedges = read_duedges nodes duedge_file in
-  (nodes, lines, duedges)
-
-let rec instrument_instr dfsan_funs edges instrs results =
-  match instrs with
-  | (Cil.Set ((Var vi, NoOffset), _, loc) as i) :: tl ->
-      let name = Cil.mkString vi.vname in
-      Cil.Call
-        ( None,
-          Cil.Lval (Cil.Var dfsan_funs.create_label, Cil.NoOffset),
-          [ name; Cil.zero ],
-          loc )
-      :: i :: results
-      |> instrument_instr dfsan_funs edges tl
-  | i :: tl -> i :: results |> instrument_instr dfsan_funs edges tl
-  | [] -> List.rev results
-
-class assignVisitor dfsan_funs edges =
-  object
-    inherit Cil.nopCilVisitor
-
-    method! vstmt s =
-      match s.Cil.skind with
-      | Cil.Instr i ->
-          s.Cil.skind <- Cil.Instr (instrument_instr dfsan_funs edges i []);
-          DoChildren
-      | _ -> DoChildren
+    let filename_of t =
+      t
+      |> (function
+           | `Assoc l -> List.assoc "loc" l | _ -> failwith "Invalid format")
+      |> (function `String s -> s | _ -> failwith "Invalid format")
+      |> String.split_on_char ':' |> Fun.flip List.nth 0
   end
 
-let instrument file pp_file _ edges =
-  Logging.log "Instrument %s (%s)" file pp_file;
-  let cil = Frontc.parse pp_file () in
-  let dfsan_funs =
-    {
-      create_label =
-        Cil.findOrCreateFunc cil "dfsan_create_label"
-          (Cil.TFun (Cil.voidType, None, false, []));
-      set_label =
-        Cil.findOrCreateFunc cil "dfsan_set_label"
-          (Cil.TFun (Cil.voidType, None, false, []));
-      get_label =
-        Cil.findOrCreateFunc cil "dfsan_get_label"
-          (Cil.TFun (Cil.voidType, None, false, []));
-      has_label =
-        Cil.findOrCreateFunc cil "dfsan_has_label"
-          (Cil.TFun (Cil.voidType, None, false, []));
-    }
-  in
-  Cil.visitCilFile (new assignVisitor dfsan_funs edges) cil;
-  let oc = open_out pp_file in
-  Cil.dumpFile !Cil.printerForMaincil oc "" cil;
-  close_out oc
+  module NodeInfoMap = struct
+    module M = Map.Make (String)
+
+    type t = NodeInfo.t M.t
+
+    let empty = M.empty
+
+    let add = M.add
+
+    let find = M.find
+  end
+
+  module LineSet = Set.Make (String)
+  module FileToEdges = Map.Make (String)
+
+  let read_nodes file =
+    let ic = open_in file in
+    Yojson.Safe.from_channel ic
+    |> (function
+         | `Assoc l -> List.assoc "nodes" l | _ -> failwith "Invalid format")
+    |> (function `Assoc l -> l | _ -> failwith "Invalid format")
+    |> List.fold_left
+         (fun map (name, info) -> NodeInfoMap.add name info map)
+         NodeInfoMap.empty
+    |> fun x ->
+    close_in ic;
+    x
+
+  let read_covered_lines file =
+    let ic = open_in file in
+    let rec loop lst =
+      match input_line ic with
+      | line -> (
+          String.split_on_char '\t' line |> function
+          | h :: _ -> loop (LineSet.add h lst)
+          | _ -> failwith "Invalid format")
+      | exception End_of_file -> lst
+    in
+    loop LineSet.empty |> fun x ->
+    close_in ic;
+    x
+
+  let read_duedges nodes file =
+    let ic = open_in file in
+    let rec loop map =
+      match input_line ic with
+      | line -> (
+          String.split_on_char '\t' line |> function
+          | src :: dst :: _ ->
+              let file = NodeInfoMap.find src nodes |> NodeInfo.filename_of in
+              FileToEdges.update file
+                (function
+                  | None -> Some [ (src, dst) ]
+                  | Some l -> Some ((src, dst) :: l))
+                map
+              |> loop
+          | _ -> failwith "Invalid format")
+      | exception End_of_file -> map
+    in
+    loop FileToEdges.empty |> fun x ->
+    close_in ic;
+    x
+
+  type dfsan_funs = {
+    create_label : Cil.varinfo;
+    set_label : Cil.varinfo;
+    get_label : Cil.varinfo;
+    has_label : Cil.varinfo;
+  }
+
+  let initialize work_dir =
+    let result_file = Filename.concat work_dir "localizer-out/result.txt" in
+    let sparrow_out_dir = Filename.concat work_dir "sparrow-out" in
+    let node_file = Filename.concat sparrow_out_dir "node.json" in
+    let duedge_file =
+      Filename.concat sparrow_out_dir "interval/datalog/DUEdge.facts"
+    in
+    let nodes = read_nodes node_file in
+    let lines = read_covered_lines result_file in
+    let duedges = read_duedges nodes duedge_file in
+    (nodes, lines, duedges)
+
+  let rec instrument_instr dfsan_funs edges instrs results =
+    match instrs with
+    | (Cil.Set ((Var vi, NoOffset), _, loc) as i) :: tl ->
+        let name = Cil.mkString vi.vname in
+        Cil.Call
+          ( None,
+            Cil.Lval (Cil.Var dfsan_funs.create_label, Cil.NoOffset),
+            [ name; Cil.zero ],
+            loc )
+        :: i :: results
+        |> instrument_instr dfsan_funs edges tl
+    | i :: tl -> i :: results |> instrument_instr dfsan_funs edges tl
+    | [] -> List.rev results
+
+  class assignVisitor dfsan_funs edges =
+    object
+      inherit Cil.nopCilVisitor
+
+      method! vstmt s =
+        match s.Cil.skind with
+        | Cil.Instr i ->
+            s.Cil.skind <- Cil.Instr (instrument_instr dfsan_funs edges i []);
+            DoChildren
+        | _ -> DoChildren
+    end
+
+  let instrument file pp_file _ edges =
+    Logging.log "Instrument %s (%s)" file pp_file;
+    let cil = Frontc.parse pp_file () in
+    let dfsan_funs =
+      {
+        create_label =
+          Cil.findOrCreateFunc cil "dfsan_create_label"
+            (Cil.TFun (Cil.voidType, None, false, []));
+        set_label =
+          Cil.findOrCreateFunc cil "dfsan_set_label"
+            (Cil.TFun (Cil.voidType, None, false, []));
+        get_label =
+          Cil.findOrCreateFunc cil "dfsan_get_label"
+            (Cil.TFun (Cil.voidType, None, false, []));
+        has_label =
+          Cil.findOrCreateFunc cil "dfsan_has_label"
+            (Cil.TFun (Cil.voidType, None, false, []));
+      }
+    in
+    Cil.visitCilFile (new assignVisitor dfsan_funs edges) cil;
+    let oc = open_out pp_file in
+    Cil.dumpFile !Cil.printerForMaincil oc "" cil;
+    close_out oc
+
+  let run work_dir src_dir =
+    let nodes, _, duedges = initialize work_dir in
+    FileToEdges.iter
+      (fun file edges ->
+        if file = "" then ()
+        else
+          let name = Filename.remove_extension file in
+          let pp_file = Filename.concat src_dir (name ^ ".i") in
+          if Sys.file_exists pp_file then instrument file pp_file nodes edges
+          else Logging.log "%s not found" file)
+      duedges
+end
+
+module GSA = struct
+  module CausalMap = Map.Make (String)
+
+  let run work_dir src_dir = failwith "Not implemented"
+end
 
 let run work_dir =
   Cil.initCIL ();
-  let nodes, _, duedges = initialize work_dir in
   let src_dir = Filename.concat work_dir "src" in
-  FileToEdges.iter
-    (fun file edges ->
-      if file = "" then ()
-      else
-        let name = Filename.remove_extension file in
-        let pp_file = Filename.concat src_dir (name ^ ".i") in
-        if Sys.file_exists pp_file then instrument file pp_file nodes edges
-        else Logging.log "%s not found" file)
-    duedges
+  match !Cmdline.instrument with
+  | Cmdline.DfSan -> DfSan.run work_dir src_dir
+  | Cmdline.GSA -> GSA.run work_dir src_dir
+  | Cmdline.Nothing -> ()

--- a/src/localizer.ml
+++ b/src/localizer.ml
@@ -119,6 +119,8 @@ let tarantula_localizer work_dir bug_desc =
       if s23 > s13 then 1 else if s23 = s13 then 0 else -1)
     taran_loc
 
+let unival_localizer work_dir bug_desc = failwith "Not implemented"
+
 let run work_dir =
   Logging.log "Start localization";
   let bug_desc = BugDesc.read work_dir in
@@ -127,6 +129,7 @@ let run work_dir =
   | Cmdline.Tarantula -> tarantula_localizer work_dir bug_desc
   | Cmdline.Prophet -> prophet_localizer work_dir bug_desc
   | Cmdline.Dummy -> dummy_localizer work_dir bug_desc
+  | Cmdline.UniVal -> unival_localizer work_dir bug_desc
 
 let print locations =
   let oc = Filename.concat !Cmdline.out_dir "result.txt" |> open_out in

--- a/src/main.ml
+++ b/src/main.ml
@@ -16,11 +16,9 @@ let main () =
   | None ->
       prerr_endline "Error: No work directory is given";
       exit 1
-  | Some work_dir when !Cmdline.instrument ->
-      initialize work_dir;
-      Instrument.run work_dir
   | Some work_dir ->
       initialize work_dir;
+      Instrument.run work_dir;
       let result = Localizer.run work_dir in
       Localizer.print result
 

--- a/src/scenario.ml
+++ b/src/scenario.ml
@@ -53,8 +53,30 @@ let configure () =
       failwith ("Error " ^ string_of_int n ^ ": configure failed")
   | _ -> failwith "configure failed"
 
+let make_clean () =
+  Unix.create_process "make" [| "make"; "clean" |] Unix.stdin Unix.stdout
+    Unix.stderr
+  |> ignore;
+  match Unix.wait () |> snd with
+  | Unix.WEXITED 0 -> ()
+  | Unix.WEXITED n ->
+      failwith ("Error " ^ string_of_int n ^ ": make clean failed")
+  | _ -> failwith "make clean failed"
+
+let make_distclean () =
+  Unix.create_process "make" [| "make"; "distclean" |] Unix.stdin Unix.stdout
+    Unix.stderr
+  |> ignore;
+  match Unix.wait () |> snd with
+  | Unix.WEXITED 0 -> ()
+  | Unix.WEXITED n ->
+      failwith ("Error " ^ string_of_int n ^ ": make distclean failed")
+  | _ -> failwith "make distclean failed"
+
 let configure_and_make () =
   Unix.chdir "src";
+  make_clean ();
+  make_distclean ();
   configure ();
   make ()
 


### PR DESCRIPTION
GSA instrument를 위한 옵션을 추가하였습니다.
이제 localizer 실행에서 `-instrument INST` 옵션을 넣어 실행하면 `INST` 에 따른 instrument를 실행합니다.
아쉽게도 아직 GSA instrument는 구현중에 있어 현재 커밋은 옵션만 추가하고 실제 함수는 fail with "Not implemented"로 때운 상태입니다.

추가로, 각 도커 컨테이너를 생성한 뒤 src 디렉토리에서 `make clean`, `make distclean`을 해준 뒤 다시 빌드해야 configure flag가 제대로 적용됨을 발견하였습니다. 이에 따라 `scenario.ml`의 `configure_and_make` 함수에 해당 커맨드 실행하도록 코드 추가하였습니다.