### PR TITLE
[Localizer and Scenario] stack overflow 방지와 gcc compile 옵션 추가

### DIFF
--- a/src/localizer.ml
+++ b/src/localizer.ml
@@ -49,15 +49,15 @@ let spec_localizer work_dir bug_desc =
           (fun file lines locs ->
             let new_locs =
               if Str.string_match regexp_pos elem.LineCoverage.test 0 then
-                List.map
+                List.rev_map
                   (fun line -> ({ Cil.file; line; byte = 0 }, 0.0, 1.0, 0.0))
                   lines
               else
-                List.map
+                List.rev_map
                   (fun line -> ({ Cil.file; line; byte = 0 }, 1.0, 0.0, 0.0))
                   lines
             in
-            locs @ new_locs)
+            List.rev_append new_locs locs)
           elem.LineCoverage.coverage locs)
       [] coverage
   in

--- a/src/scenario.ml
+++ b/src/scenario.ml
@@ -118,9 +118,9 @@ let configure () =
   Unix.create_process "./configure"
     [|
       "./configure";
-      "CFLAGS=--coverage --save-temps";
+      "CFLAGS=--coverage --save-temps -Wno-error";
       "CXXFLAGS=--coverage --save-temps";
-      "LDFLAGS=-lgcov";
+      "LDFLAGS=-lgcov --coverage";
     |]
     Unix.stdin Unix.stdout Unix.stderr
   |> ignore;


### PR DESCRIPTION
Localizer에서 non-tail recursion으로 인한 stack overflow를 방지하기 위해 tail recursion 방식으로 변경하였습니다.

python 프로젝트에서 undefined reference to __gcov_init() 에러를 방지하기 위해 gcc option 중  LDFLAGS에 --coverage 를 추가했습니다.
wireshark 프로젝트에서 warning을  error로 처리하는 문제를 방지하기 위해 gcc option 중  CFLAGS에 -Wno-error 를 추가했습니다.