### PR TITLE
GSA_Gen instrument 중간 완성

### DIFF
--- a/src/cmdline.ml
+++ b/src/cmdline.ml
@@ -25,7 +25,9 @@ let select_engine s =
   | "jaccard" -> engine := Jaccard
   | "ochiai" -> engine := Ochiai
   | "dummy" -> engine := Dummy
-  | "unival" -> engine := UniVal
+  | "unival" ->
+      engine := UniVal;
+      instrument := GSA
   | "all" -> engine := All
   | _ -> failwith "Unknown engine"
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -18,7 +18,6 @@ let main () =
       exit 1
   | Some work_dir ->
       initialize work_dir;
-      Instrument.run work_dir;
       Localizer.run work_dir
 
 let _ = main ()

--- a/test/simple1/compile.sh
+++ b/test/simple1/compile.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-gcc -o bug --coverage -lgcov -g src/bug.c
+cd src
+gcc -o bug --coverage --save-temps -lgcov -g bug.c
+cd ..


### PR DESCRIPTION
UniVal에서 GSA_Gen에 해당하는 instrument 코드를 1차적으로 완성하였습니다.
코드는 GSA form으로 instrument되며, causalMap은 뽑아내는 부분까지 완성하였으나, 아직 이를 텍스트파일로 출력하여 저장하는 부분이 완성되지 않아 직접 확인은 아직 불가능합니다. 해당 코드 역시 곧 추가할 예정입니다.
이제 `-engine` 옵션을 unival로 지정하면, `instrument` 옵션이 자동으로 GSA_Gen으로 설정되어 instrument 옵션을 따로 지정해주지 않고 무조건 GSA_Gen이 되도록 수정하였습니다.
UniVal은 다른 spectrum based 엔진들과 달리 컴파일만 먼저 한 뒤 instrument 과정을 거쳐 테스팅을 진행하기 때문에, localizer 부분에서 compile 함수를 따로 만들어 순서를 조금 다르게 수정하였습니다.