### PR TITLE
GSA_Gen 이후 data profile을 위한 flush용 코드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ coverage.xml
 *.gc*
 bug
 *.i
+*.o
+*.s
+CausalMap.txt


### PR DESCRIPTION
UniVal에서 GSA_Gen 이후, 즉 instrument 이후 data profile을 진행할 때 각 테스트를 실행하면서 어떤 변수에 어떤 값이 할당되는지 output.txt 파일에 출력하게 됩니다. 이 과정을 위한 `unival_record` 함수 코드를 추가하였습니다.
이제 `-engine` 옵션을 unival로 하는 경우, `unival_record` 함수를 정의하는 코드가 `bugzoo_sighandler` 뒷부분에 instrument됩니다.
이 함수는 instrument 이후 data profiling 과정에서 각 변수와 그 값을 출력해줍니다.
다만 현재로써는 `unival_record` 함수의 구현 방식이 테스트 방식의 한계 때문에 stdout에 그대로 출력하는 형태이며, 추후 이를 파일 출력으로 변경하거나 테스트 방식을 바꿔야 할 것으로 예상됩니다.

그 외에 instrument 과정에서 일어난 몇가지 버그를 수정하였습니다.