### PR TITLE
unival_record 함수를 추가해 주는 부분 수정 중 push

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -10,5 +10,6 @@
   coverage
   bugDesc
   scenario
-  instrument)
+  instrument
+  utils)
  (libraries str cil cil.all-features xmlm unix yojson))

--- a/src/localizer.ml
+++ b/src/localizer.ml
@@ -190,10 +190,28 @@ let unival_compile scenario bug_desc =
   Scenario.compile scenario bug_desc.BugDesc.compiler_type;
   Unix.chdir scenario.Scenario.work_dir
 
+let unival_run_test work_dir scenario bug_desc =
+  Logging.log "Start test";
+  List.iter
+    (fun test ->
+      Unix.create_process scenario.Scenario.test_script
+        [| scenario.Scenario.test_script; test |]
+        Unix.stdin Unix.stdout
+        (* (Unix.openfile
+           (Filename.concat work_dir "output.txt")
+           [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_CREAT ]
+           0o775) *)
+        Unix.stderr
+      |> ignore;
+      Unix.wait () |> ignore)
+    bug_desc.BugDesc.test_cases
+
 let unival_localizer work_dir bug_desc =
   let scenario = Scenario.init work_dir in
   unival_compile scenario bug_desc;
   Instrument.run scenario.work_dir;
+  unival_compile scenario bug_desc;
+  unival_run_test work_dir scenario bug_desc;
   failwith "Not implemented"
 
 let print locations resultname =

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -1,0 +1,33 @@
+let rec join strlist delimiter =
+  match strlist with
+  | [ hd ] -> hd
+  | hd :: tl -> hd ^ delimiter ^ join tl delimiter
+  | [] -> ""
+
+let remove_unnec_file filename =
+  if not (Sys.file_exists (Filename.remove_extension filename ^ ".c")) then ()
+  else (
+    print_endline ("Remove " ^ filename);
+    Unix.create_process "rm" [| "rm"; "-f"; filename |] Unix.stdin Unix.stdout
+      Unix.stderr
+    |> ignore;
+    Unix.wait () |> ignore)
+
+let rec remove_temp_files root_dir =
+  let files = Sys.readdir root_dir in
+  Array.iter
+    (fun file ->
+      let file_path = Filename.concat root_dir file in
+      print_endline file_path;
+      if (Unix.lstat file_path).st_kind = Unix.S_LNK then ()
+      else if Sys.is_directory file_path then
+        if Filename.check_suffix file_path ".hg" then ()
+        else remove_temp_files file_path
+      else if
+        List.mem (Filename.extension file)
+          [ ".i"; ".lo"; ".s"; ".gcno"; ".o"; ".asm" ]
+      then remove_unnec_file file_path
+      else ())
+    files
+
+let dash2under_bar s = String.map (fun c -> if c = '-' then '_' else c) s


### PR DESCRIPTION
unival_record 함수를 각 .c 파일 마다 다른 이름으로 define하여 컴파일을 시도하던 흔적입니다. 이 방법 역시도 컴파일이 되지 않아 그냥 함수 호출 없이 statement를 끼워넣는 식으로 수정할 예정입니다.
그 외에, unival을 실행하면 instrument 이후 컴파일 및 테스트를 하는 코드가 추가되었습니다만, 위의 이유로 인해 아직 이 부분까지 완전히 실행되지 못합니다.

추가적으로, 코드가 복잡해지고 꼭 해당 모듈 안에서만 사용할 함수가 아닌 범용적인 함수들을 utils.ml 파일로 빼두는 작업을 하는 중입니다. unival 이외에도 그러한 함수가 있다면 옮겨 주시면 감사하겠습니다.