### PR TITLE
coverage instrument 수정

### DIFF
--- a/src/instrument.ml
+++ b/src/instrument.ml
@@ -492,7 +492,8 @@ module GSA = struct
     Array.iter
       (fun file ->
         let file_path = Filename.concat root_dir file in
-        if Sys.is_directory file_path then
+        if (Unix.lstat file_path).st_kind = Unix.S_LNK then ()
+        else if Sys.is_directory file_path then
           if Filename.check_suffix file_path ".hg" then ()
           else traverse_pp_file f file_path
         else if Filename.extension file = ".i" then f file_path


### PR DESCRIPTION
- coverage instrument 과정에서 traverse_pp_file이 심볼릭 링크 파일 역시 instrument하려다 원본 파일이 삭제된 링크 파일을 건드려 뻗어 버리는 문제를 해결했습니다.
- coverage instrument 과정에서 stmt 단위로 fprintf, fflush가 삽입되는데, cil 구조상 instr(set, call) list는 하나의 stmt로 묶여 있기 때문에 여러 줄로 되어 있는 assignment들은 가장 앞줄만 커버리지가 찍히는 문제를 발견하였습니다. 이에 instr list 하나하나 커버리지가 찍힐 수 있도록 수정하였습니다. gcov로 커버리지를 찍을 때보다 현저히 적은 결과가 나왔던 원인 중 하나로 파악됩니다.