### PR TITLE
coverage instrument 개선

### DIFF
--- a/src/coverage.ml
+++ b/src/coverage.ml
@@ -151,7 +151,10 @@ module LineCoverage2 = struct
     s
 
   let update_coverage coverage_data test coverage =
-    let data = read_whole_file coverage_data |> String.split_on_char '\n' in
+    let data =
+      try read_whole_file coverage_data |> String.split_on_char '\n'
+      with Sys_error _ -> []
+    in
     let elem =
       List.fold_left
         (fun elem line ->

--- a/src/coverage.ml
+++ b/src/coverage.ml
@@ -155,7 +155,7 @@ module LineCoverage2 = struct
     let elem =
       List.fold_left
         (fun elem line ->
-          if line = "" then elem
+          if List.mem line [ ""; "__START_NEW_EXECUTION__" ] then elem
           else
             let lst = String.split_on_char ':' line in
             let filename, lineno =
@@ -186,12 +186,15 @@ module LineCoverage2 = struct
     Scenario.compile scenario bug_desc.BugDesc.compiler_type;
     Unix.chdir scenario.Scenario.work_dir;
     Logging.log "Start test";
+    let cov_path = Filename.concat scenario.work_dir "coverage.txt" in
     List.fold_left
       (fun coverage test ->
         Scenario.run_test scenario.test_script test;
-        update_coverage
-          (Filename.concat scenario.work_dir "coverage.txt")
-          test coverage)
+        let cur_cov_path =
+          Filename.concat !Cmdline.out_dir ("coverage." ^ test ^ ".txt")
+        in
+        Unix.system ("mv " ^ cov_path ^ " " ^ cur_cov_path) |> ignore;
+        update_coverage cur_cov_path test coverage)
       empty bug_desc.BugDesc.test_cases
     |> List.map elem_of_internal
 end

--- a/src/instrument.ml
+++ b/src/instrument.ml
@@ -492,7 +492,8 @@ module GSA = struct
     Array.iter
       (fun file ->
         let file_path = Filename.concat root_dir file in
-        if Sys.is_directory file_path then
+        if (Unix.lstat file_path).st_kind = Unix.S_LNK then ()
+        else if Sys.is_directory file_path then
           if Filename.check_suffix file_path ".hg" then ()
           else traverse_pp_file f file_path
         else if Filename.extension file = ".i" then f file_path

--- a/src/scenario.ml
+++ b/src/scenario.ml
@@ -28,7 +28,7 @@ let bugzoo_instrument_code () =
       "#endif\n";
       "#ifndef BUGZOO_CTOR\n";
       "#define BUGZOO_CTOR 1\n";
-      "static void bugzoo_ctor (void) __attribute__ ((constructor));\n";
+      "static void bugzoo_ctor (void) __attribute__ ((constructor(103)));\n";
       "static void bugzoo_ctor (void) {\n";
       "  struct sigaction new_action;\n";
       "  new_action.sa_handler = bugzoo_sighandler;\n";
@@ -167,7 +167,8 @@ let init ?(stdio_only = false) work_dir =
     else work_dir
   in
   let preamble =
-    if stdio_only then "#include <stdio.h>" else bugzoo_instrument_code ()
+    (* if stdio_only then "#include <stdio.h>" else bugzoo_instrument_code () *)
+    bugzoo_instrument_code ()
   in
   file_instrument_all work_dir preamble;
   {


### PR DESCRIPTION
새로 구현한 coverage instrument에서 몇가지 사항을 개선하였습니다.
- 임시적으로, `#include <stdio.h>`를 추가해주는 부분을 주석처리하였습니다. 실행 결과 warning이 뜨지만 큰 문제 없이 기록되는 것으로 보입니다.
- `__attribute__ ((constructor))`로 선언되는 함수가 여럿임을 감안해, 안전성을 위해 priority를 추가했습니다.
- `coverage.txt`가 각 테스트를 새로 실행할 때마다 덮어 씌워지는 문제를 해결하였습니다. 또한 하나의 test suite에서 여러 번 실행되는 경우와, 서로 다른 test suite를 연속하여 실행하는 경우를 구분하기 위해 `coverage.txt` 파일을 각 test suite별로 구분하여 `out_dir`에 저장되도록 하였습니다. (e.g. `p1` test suite를 실행하는 경우, 그 안에서 프로젝트가 몇 번 실행되든 `coverage.p1.txt`에 누적되어 기록됨)